### PR TITLE
Telemetry

### DIFF
--- a/experiment_buddy/experiment_buddy.py
+++ b/experiment_buddy/experiment_buddy.py
@@ -20,6 +20,7 @@ import yaml
 from invoke import UnexpectedExit
 from paramiko.ssh_exception import SSHException
 
+import experiment_buddy.utils
 from experiment_buddy.utils import get_backend
 from experiment_buddy.utils import get_project_name
 
@@ -158,6 +159,7 @@ class WandbWrapper:
         self.run.watch(*args, **kwargs)
 
 
+@experiment_buddy.utils.telemetry
 def deploy(host: str = "", sweep_yaml: str = "", proc_num: int = 1, wandb_kwargs=None, extra_slurm_headers="") -> WandbWrapper:
     if wandb_kwargs is None:
         wandb_kwargs = {}

--- a/experiment_buddy/utils.py
+++ b/experiment_buddy/utils.py
@@ -1,11 +1,11 @@
 import enum
-import requests
 import os
 import time
 
 import fabric
 import git
 import invoke
+import requests
 
 
 class Backend(enum.Enum):
@@ -46,7 +46,7 @@ def telemetry(f):
         retr = f(*args, **kwargs)
         toc = time.perf_counter()
         method_name = f.__name__
-        requests.get(f"65.21.155.92/{method_name}/{toc - tic}", timeout=2.)
+        requests.get(f"http://65.21.155.92/{method_name}/{toc - tic}", timeout=2.)
         return retr
 
     return wrapped_f

--- a/experiment_buddy/utils.py
+++ b/experiment_buddy/utils.py
@@ -1,9 +1,11 @@
 import enum
+import requests
 import os
+import time
 
 import fabric
-import invoke
 import git
+import invoke
 
 
 class Backend(enum.Enum):
@@ -36,3 +38,15 @@ def get_project_name(git_repo: git.Repo) -> str:
     remote_url = git_repo_remotes[0].config_reader.get("url")
     project_name, _ = os.path.splitext(os.path.basename(remote_url))
     return project_name
+
+
+def telemetry(f):
+    def wrapped_f(*args, **kwargs):
+        tic = time.perf_counter()
+        retr = f(*args, **kwargs)
+        toc = time.perf_counter()
+        method_name = f.__name__
+        requests.get(f"65.21.155.92/{method_name}/{toc - tic}", timeout=2.)
+        return retr
+
+    return wrapped_f


### PR DESCRIPTION
Telemetry wrapper that pings our server with the deployment time.
in case of failure of the ping, deployment still works but maybe we should silently ignore the exception?